### PR TITLE
Common Directories

### DIFF
--- a/Sources/Path+CommonDirectories.swift
+++ b/Sources/Path+CommonDirectories.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension Path {
+    // helper to allow search path and domain mask to be passed in
+    private static func pathFor(searchPathDirectory path: FileManager.SearchPathDirectory, domain: FileManager.SearchPathDomainMask = .userDomainMask) -> Path? {
+        guard let pathString = FileManager.default.urls(for: path, in: .userDomainMask).last?.relativeString else {
+            return nil
+        }
+
+        return Path(string: pathString)
+    }
+
+    public static var documents: Path? {
+        return pathFor(searchPathDirectory: .documentDirectory)
+    }
+
+    public static var caches: Path? {
+        return pathFor(searchPathDirectory: .cachesDirectory)
+    }
+
+    public static var applicationSupport: Path? {
+        return pathFor(searchPathDirectory: .applicationSupportDirectory)
+    }
+}


### PR DESCRIPTION
I noticed that the project isn't labelled as "iOS" compatible, yet it appears to works fine.

I added some hooks for iOS common directories - Documents, Caches and Application Support. These are also compatible with MacOS too. 

These are optional as the NSFileManager has no direct hooks to them, and thus returns an array of paths. I figured Optionals were better than a `throw` or a `preconditionFailure`