### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Path.root/"~b"     // => /~b
 Path.root/"~/b"    // => /~/b
 
 // but is here
-Path("~/foo")!     // => /Users/foo
+Path("~/foo")!     // => /Users/mxcl/foo
 
 // this does not work though
 Path("~foo")       // => nil


### PR DESCRIPTION
Existing `testJoin()` line 109 ( `XCTAssertEqual(Path("~/foo"), Path.home/"foo")` ) and my own tests suggest this is a minor typo in the documentation.