### PR TITLE
Bundle extensions don’t return optional Paths

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -10,13 +10,31 @@ public extension Bundle {
     }
 
     /// Returns the path for the shared-frameworks directory in this bundle.
-    var sharedFrameworks: Path? {
-        return sharedFrameworksPath.flatMap(Path.init)
+    var sharedFrameworks: Path {
+        var `default`: Path {
+          #if os(macOS)
+            return path.join("Contents/Frameworks")
+          #elseif os(Linux)
+            return path.join("lib")
+          #else
+            return path.join("Frameworks")
+          #endif
+        }
+        return sharedFrameworksPath.flatMap(Path.init) ?? `default`
     }
 
     /// Returns the path for the resources directory in this bundle.
-    var resources: Path? {
-        return resourcePath.flatMap(Path.init)
+    var resources: Path {
+        var `default`: Path {
+          #if os(macOS)
+            return path.join("Contents/Resources")
+          #elseif os(Linux)
+            return path.join("share")
+          #else
+            return path
+          #endif
+        }
+        return resourcePath.flatMap(Path.init) ?? `default`
     }
 
     /// Returns the path for this bundle.


### PR DESCRIPTION
Rationale: Paths are not guaranteed to exist, the Bundle functions return optional if the path doesn't exist. So we'll provide a sensible default instead and you need to check the result exists at some point instead.

This makes more elegant chains, the chain will fail when you operate on it, but you don’t have to do a check for optional first. Or risk a bang.