### PR TITLE
These deployment versions are the defaults

### DIFF
--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -12,9 +12,6 @@ let pkg = Package(
     ]
 )
 
-pkg.platforms = [
-   .macOS(.v10_10), .iOS(.v8), .tvOS(.v10), .watchOS(.v3)
-]
 pkg.swiftLanguageVersions = [
     .v4_2, .v5
 ]


### PR DESCRIPTION
Well, almost, but adjusted we still work so in fact the ”bump” was spurious.