### PR TITLE
Adds `kind` fixes deleting broken symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,15 @@ for that as the check was deemed too expensive to be worthwhile.
     equality check is required.
 * There are several symlink paths on Mac that are typically automatically
     resolved by Foundation, eg. `/private`, we attempt to do the same for
-    functions that you would expect it (notably `realpath`), but we do *not* for
-    `Path.init`, *nor* if you are joining a path that ends up being one of these
-    paths, (eg. `Path.root.join("var/private')`).
+    functions that you would expect it (notably `realpath`), we *do* the same for
+    `Path.init`, but *do not* if you are joining a path that ends up being one of
+    these paths, (eg. `Path.root.join("var/private')`).
+
+If a `Path` is a symlink but the destination of the link does not exist `exists`
+returns `false`. This seems to be the correct thing to do since symlinks are
+meant to be an abstraction for filesystems. To instead verify that there is
+no filesystem entry there at all check if `kind` is `nil`.
+
 
 ## We do not provide change directory functionality
 

--- a/Sources/Path+Attributes.swift
+++ b/Sources/Path+Attributes.swift
@@ -83,4 +83,22 @@ public extension Path {
     #endif
         return self
     }
+
+    enum Kind {
+        case file, symlink, directory
+    }
+
+    var kind: Kind? {
+        var buf = stat()
+        guard lstat(string, &buf) == 0 else {
+            return nil
+        }
+        if buf.st_mode & S_IFMT == S_IFLNK {
+            return .symlink
+        } else if buf.st_mode & S_IFMT == S_IFDIR {
+            return .directory
+        } else {
+            return .file
+        }
+    }
 }

--- a/Sources/Path->Bool.swift
+++ b/Sources/Path->Bool.swift
@@ -8,7 +8,10 @@ import Darwin
 public extension Path {
     //MARK: Filesystem Properties
 
-    /// Returns true if the path represents an actual filesystem entry.
+    /**
+     - Returns: `true` if the path represents an actual filesystem entry.
+     - Note: If `self` is a symlink the return value represents the destination.
+     */
     var exists: Bool {
         return FileManager.default.fileExists(atPath: string)
     }

--- a/Tests/PathTests/XCTestManifests.swift
+++ b/Tests/PathTests/XCTestManifests.swift
@@ -27,6 +27,7 @@ extension PathTests {
         ("testInitializerForRelativePath", testInitializerForRelativePath),
         ("testIsDirectory", testIsDirectory),
         ("testJoin", testJoin),
+        ("testKind", testKind),
         ("testLock", testLock),
         ("testMkpathIfExists", testMkpathIfExists),
         ("testMktemp", testMktemp),


### PR DESCRIPTION
`delete()` and other functions would check `exists` to do certain behaviors, but `exists` will validate a symlink if the entry is a symlink, thus instead we check if the path is an actual entry now instead.