### PR TITLE
Fix Path.Finder use case when a hidden file and a regular subdirectory are in the same level

### DIFF
--- a/Tests/PathTests/PathTests+ls().swift
+++ b/Tests/PathTests/PathTests+ls().swift
@@ -157,6 +157,31 @@ extension PathTests {
             #endif
         }
     }
+
+    func testFindHiddenFileAlongsideDirectory() throws {
+        try Path.mktemp { tmpdir in
+            let dotFoo = try tmpdir.join(".foo.txt").touch()
+            let tmpDotA = try tmpdir.join(".a").mkdir()
+            let tmpDotAFoo = try tmpdir.join(".a").join("foo.txt").touch()
+            let tmpB = try tmpdir.b.mkdir()
+            let tmpBFoo = try tmpB.join("foo.txt").touch()
+            let dotBar = try tmpB.join(".bar.txt").touch()
+            let tmpC = try tmpdir.b.c.mkdir()
+            let bar = try tmpC.join("bar.txt").touch()
+
+            XCTAssertEqual(
+                Set(tmpdir.find().hidden(true)),
+                Set([dotFoo,tmpDotA,tmpDotAFoo,tmpB,tmpBFoo,tmpC,dotBar,bar]),
+                relativeTo: tmpdir)
+            
+            #if !os(Linux) || swift(>=5)
+            XCTAssertEqual(
+                Set(tmpdir.find().hidden(false)),
+                Set([tmpB,tmpBFoo,tmpC,bar]),
+                relativeTo: tmpdir)
+            #endif
+        }
+    }
     
     func testFindExtension() throws {
         try Path.mktemp { tmpdir in


### PR DESCRIPTION
When using **Path.swift** to build a tool, I noticed it had a bug related to its implementation around `FileManager.DirectoryEnumerator`. Here is a sample use case, which I added a test case to cover.

Imagine you have the following file tree:

```
.
├── .a
│   └── foo.txt
├── .foo.txt
└── b
    ├── .bar.txt
    ├── c
    │   └── bar.txt
    └── foo.txt
```

When running `find()` on root, including hidden files, one would expect to get all files and directories - and this is working fine. However, when setting `.hidden(false)`, only the directory `b` is returned - and not `b/c`, `b/c/bar.txt`, nor `b/foo.txt`.

This happens because of [these lines](https://github.com/mxcl/Path.swift/blob/46b0cd883b80543f5918b3478172cd838d38ea88/Sources/Path%2Bls.swift#L57-L59) in the `next()` method in `Path.Finder`:

```
if !hidden, path.basename().hasPrefix(".") {
    enumerator.skipDescendents()
    continue
}
```

When finding the first hidden file or directory, `skipDescendants()` is called. And according to [the docs](https://developer.apple.com/documentation/foundation/filemanager/directoryenumerator/1412990-skipdescendents), this is what it does:

> Causes the receiver to skip recursion into the most recently obtained subdirectory.

This means that, when the first hidden file is found, and `skipDescendants()` is called, all files and directories residing alongside the hidden file are skipped.

This PR adds a check, and only calls `skipDescendants()` if the path in question is a directory - if it's just a file, then nothing should be skipped, as other files might be "waiting" to be enumerated. 

Additionally, I changed the `FileManager.DirectoryEnumerator` initialization to use a more modern API, that can receive a list of [`URLResourceKey`](https://developer.apple.com/documentation/foundation/urlresourcekey)s, and passes `.isDirectoryKey` - this way, there's no need to do an extra disk read for each `isDirectory` check, as they're fetched on the enumeration stage and only read via a `URL`'s `URLResourceValues`.