### PR TITLE
Add 'Sendable' conformance to Path

### DIFF
--- a/Sources/Path.swift
+++ b/Sources/Path.swift
@@ -9,6 +9,10 @@ let _realpath = Glibc.realpath
 
 public typealias PathStruct = Path
 
+#if !swift(>=5.5)
+    private protocol Sendable {}
+#endif
+
 /**
  A `Path` represents an absolute path on a filesystem.
 
@@ -40,7 +44,7 @@ public typealias PathStruct = Path
  - Note: A `Path` does not necessarily represent an actual filesystem entry.
  - SeeAlso: `Pathish` for most methods you will use on `Path` instances.
  */
-public struct Path: Pathish {
+public struct Path: Pathish, Sendable {
 
     /// The normalized string representation of the underlying filesystem path
     public let string: String


### PR DESCRIPTION
Add `Sendable` conformance to `Path`. Closes #95 .

I don't see any way to test this explicitly with unit tests, as the correctness is supposedly already entirely checked by the compiler.

We could add this conformance directly of the `Pathish` protocol, but I ruled against it because this could break some code if someone had a non-sendable type already adopting `Pathish`.

I added a dummy / empty `Sendable` protocol when compiling in Swift language mode < 5.5, to prevent compilation errors (the "real" `Sendable` protocol does not exist yet in these language modes).